### PR TITLE
Fix background comment typo

### DIFF
--- a/src/Includes/CustomWidgets/Custom.hpp
+++ b/src/Includes/CustomWidgets/Custom.hpp
@@ -79,7 +79,7 @@ namespace Custom {
 		const ImVec2 pos = ImGui::GetWindowPos( );
 		ImDrawList * draw = ImGui::GetWindowDrawList( );
 
-		//Brackground
+                //Background
 		draw->AddRectFilled( ImVec2( pos.x + 0, pos.y + 0 ), ImVec2( pos.x + g_MenuInfo.MenuSize.x, pos.y + g_MenuInfo.MenuSize.y ), ImGui::GetColorU32( g_Col.BackgroundCol ), 6.f );
 
 		//TitleBar


### PR DESCRIPTION
## Summary
- fix a typo in Custom.hpp comment that spelled `Brackground`

## Testing
- `clang-format --version`

------
https://chatgpt.com/codex/tasks/task_e_686196435828832d9976b3ca39b66e59